### PR TITLE
Updates to source while working on the point version.

### DIFF
--- a/SOURCE_CODE_05.13.2017/casaoffline_driver_clm.f90
+++ b/SOURCE_CODE_05.13.2017/casaoffline_driver_clm.f90
@@ -33,7 +33,7 @@ PROGRAM offline_casacnp
   USE corpsevariable
 
   IMPLICIT NONE
-  integer mst, mvt, mloop, nloop, mdaily
+  integer mst, mvt, mloop, nloop, mdaily, myear
   integer tyear1, tyear2, ityear, idx, idx2
   integer mreps, irep, iYrCnt, nctime
   character(len=100) :: filename_cnppoint,filename_phen, &
@@ -245,10 +245,12 @@ PROGRAM offline_casacnp
 
   else if (isomModel == CORPSE) then
 
-      print *, 'calling corpse_init'
+      call GetMetNcFileDim(filename_cnpmet, ms, myear)
+
       !! ATTENTION: The allocation of output variables may need to be moved after met.nc file is read to get the exact # simulation years.
       if (initcasa < 2) then
-          maxSteps = mloop * 365 * 7                          ! 7 is the maximum number of years in a spinup file (daily time step - mdh 3/21/2016)
+          !maxSteps = mloop * 365 * 7                         ! 7 is the maximum number of years in a spinup file (daily time step - mdh 3/21/2016)
+          maxSteps = mloop * 365 * myear                      ! myear is the number of years in a spinup file (daily time step - mdh 1/30/2018)
       else
           maxSteps = mloop * 365 * abs(tyear2 - tyear1 + 1)   ! Assumes each transient year met.nc file has 365 days  (daily time step - mdh 3/21/2016)
       endif

--- a/SOURCE_CODE_05.13.2017/corpse_cycle.f90
+++ b/SOURCE_CODE_05.13.2017/corpse_cycle.f90
@@ -256,11 +256,12 @@ SUBROUTINE corpse_soil(mp,idoy,cleaf2met,cleaf2str,croot2met,croot2str,cwd2str,c
                   theta_frzn(npt) = min(1.0, casamet%frznmoistavg(npt)/soil%ssat(npt)) ! fraction of frozen water-filled pore space (0.0 - 1.0)
                   air_filled_porosity = max(0.0, 1.0-theta_liq(npt)-theta_frzn(npt))
 
+                  ! fW and fT are output variables only.  To update actual function, go to function Resp in corpse_soil_carbon.f90. -mdh 12/18/2017
                   ! fW(npt)=(theta_liq(npt)**3+0.001)*max((air_filled_porosity)**gas_diffusion_exp,min_anaerobic_resp_factor)
-                  fW(npt) = (theta_liq(npt)**3+0.001)*max((air_filled_porosity)**2.5,0.003)
-!                 fW(npt) = max(0.05*0.022600567942709, fW(npt))  !WW added 12.14.2017 to put lower limit on CORPSE, similar to MIMICS
-                  fW(npt) = max(0.0001                , fW(npt))  !WW added 12.16.2017 to put lower limit on CORPSE, similar to MIMICS
-                  fT(npt) = 0.0 ! placeholder for future output, if needed
+                  fW(npt) = max(pt(npt)%soil(jj)%fWmin, &
+                           (theta_liq(npt)**3+0.001)*max((air_filled_porosity)**pt(npt)%soil(jj)%gas_diffusion_exp, &
+                                                          pt(npt)%soil(jj)%min_anaerobic_resp_factor))
+                  fT(npt) = 0.0 ! placeholder for future output variable, if needed
 
                   call update_pool(pool=pt(npt)%soil(jj), &
                                T=T, &

--- a/SOURCE_CODE_05.13.2017/corpse_inout.f90
+++ b/SOURCE_CODE_05.13.2017/corpse_inout.f90
@@ -12,7 +12,7 @@
 !     SUBROUTINE save_output_line - records carbon sums from one pool into the output data container 
 !                for that pool
 !     SUBROUTINE corpse_caccum - accumulate daily C fluxes and pool values and annual mean each year
-!     SUBROUTINE WritePointCorpse - write all saved output variables for a sigle point to .csv file
+!     SUBROUTINE WritePointCORPSE - write all saved output variables for a sigle point to .csv file
 !                Recordtime in corpse_params.nml file determines the number of timesteps that are saved.
 !     SUBROUTINE corpse_poolfluxout - write all saved output variables for the entire grid to restart 
 !                .csv output file for the final time saved.
@@ -552,7 +552,7 @@ END SUBROUTINE corpse_caccum
 ! Write ALL SAVED output variables and ALL SAVED timesteps for A SINGLE POINT .csv file filenamePtCORPSE.
 ! Recordtime in corpse_params.nml file determines the number of timesteps that are saved.
 !
-SUBROUTINE WritePointCorpse(filenamePtCORPSE,iptToSaveIndx,mp)
+SUBROUTINE WritePointCORPSE(filenamePtCORPSE,iptToSaveIndx,mp)
     USE casavariable
     USE define_types
     USE corpsevariable
@@ -617,7 +617,7 @@ SUBROUTINE WritePointCorpse(filenamePtCORPSE,iptToSaveIndx,mp)
 
     if (verbose .ge. 0) print *, "Done writing output to file ", trim(filenamePtCORPSE), "..."
 
-end subroutine WritePointCorpse
+end subroutine WritePointCORPSE
 
 !--------------------------------------------------------------------------------------------------------------
 ! Write END-OF-SIMULATION values for all saved output variables for the entire grid to filename_corpseepool

--- a/SOURCE_CODE_05.13.2017/mimics_cycle.f90
+++ b/SOURCE_CODE_05.13.2017/mimics_cycle.f90
@@ -355,9 +355,9 @@ SUBROUTINE mimics_soil_forwardMM(mp,iYrCnt,idoy,cleaf2met,cleaf2str,croot2met,cr
   REAL(r_2), parameter :: wfpscoefd=3.22   ! Kelly et al. (2000) JGR, Figure 2b)
   REAL(r_2), parameter :: wfpscoefe=6.6481 ! =wfpscoefd*(wfpscoefb-wfpscoefa)/(wfpscoefa-wfpscoefc)
 
-  if (iptToSave_mimics > 0) then
-      open(214,file=sPtFileNameMIMICS, access='APPEND')
-  endif
+! if (iptToSave_mimics > 0) then
+!     open(214,file=sPtFileNameMIMICS, access='APPEND')
+! endif
 
   NHOURSf = real(NHOURS)
 
@@ -538,46 +538,51 @@ SUBROUTINE mimics_soil_forwardMM(mp,iYrCnt,idoy,cleaf2met,cleaf2str,croot2met,cr
 !     if (casamet%ijgcm(npt) .eq. 10919) then    ! Deciduous broadleaf (4)
 !     if (casamet%ijgcm(npt) .eq. 11018) then    ! Evergreen needleleaf (1)
 !     if (casamet%ijgcm(npt) .eq. 11569) then    ! Evergreen broadleaf (2)
+
       if (casamet%ijgcm(npt) .eq. iptToSave_mimics) then 
-          write(214,102) npt,casamet%ijgcm(npt),iYrCnt,idoy,casamet%tsoilavg(npt),mimicsflux%Chresp(npt), &
-                         mimicsflux%ClitInput(npt,metbc),mimicsflux%ClitInput(npt,struc), &
-                         mimicspool%LITm(npt),mimicspool%LITs(npt),mimicspool%MICr(npt), &
-                         mimicspool%MICk(npt),mimicspool%SOMa(npt),mimicspool%SOMc(npt),mimicspool%SOMp(npt), &
-                         dLITm, dLITs, dMICr, dMICk, dSOMa, dSOMc, dSOMp,&
 
-                         LITmin(1), LITmin(2), LITmin(3), LITmin(4), &
-                         MICtrn(1), MICtrn(2), MICtrn(3), MICtrn(4), MICtrn(5), MICtrn(6), &
-                         SOMmin(1), SOMmin(2), DEsorb, OXIDAT, mimicsbiome%fmet(npt), &
+          call WritePointMIMICS(214, sPtFileNameMIMICS, npt, mp, iYrCnt, idoy, &
+              cleaf2met,cleaf2str,croot2met,croot2str,cwd2str,cwd2co2,cwood2cwd, &
+              LITmin, MICtrn, SOMmin, DEsorb, OXIDAT, &
+              dLITm, dLITs, dSOMa, dSOMc, dSOMp, dMICr, dMICk, Tsoil)
 
-                         mimicsbiome%tauMod(npt), mimicsbiome%tauR(npt), mimicsbiome%tauK(npt), &
-                         mimicsbiome%Vmax(npt,R1),mimicsbiome%Vmax(npt,R2),mimicsbiome%Vmax(npt,R3), &
-                         mimicsbiome%Vmax(npt,K1),mimicsbiome%Vmax(npt,K2),mimicsbiome%Vmax(npt,K3), &
-                         mimicsbiome%Km(npt,R1),mimicsbiome%Km(npt,R2),mimicsbiome%Km(npt,R3), &
-                         mimicsbiome%Km(npt,K1),mimicsbiome%Km(npt,K2),mimicsbiome%Km(npt,K3), &
-                         mimicsbiome%Vslope(R1),mimicsbiome%Vslope(R2),mimicsbiome%Vslope(R3), &
-                         mimicsbiome%Vslope(K1),mimicsbiome%Vslope(K2),mimicsbiome%Vslope(K3), &
-                         mimicsbiome%Kslope(R1),mimicsbiome%Kslope(R2),mimicsbiome%Kslope(R3), &
-                         mimicsbiome%Kslope(K1),mimicsbiome%Kslope(K2),mimicsbiome%Kslope(K3), &
-                         mimicsbiome%Vint(R1),mimicsbiome%Kint(R1),Tsoil,casamet%moistavg(npt), &
-
-                         casaflux%CnppAn(npt),casapool%clitter(npt,cwd),mimicsbiome%ligninNratioAvg(npt), &
-                         cleaf2met(npt),cleaf2str(npt),croot2met(npt),croot2str(npt), &
-                         cwd2str(npt),cwd2co2(npt),cwood2cwd(npt), &
-
-                         mimicsbiome%fAVAL(npt,1), mimicsbiome%fAVAL(npt,2), mimicsbiome%fCHEM(npt,1), &
-                         mimicsbiome%fCHEM(npt,2), mimicsbiome%fPHYS(npt,1), mimicsbiome%fPHYS(npt,2), &
-
-                         mimicsbiome%Kmod(npt,R1),mimicsbiome%Kmod(npt,R2),mimicsbiome%Kmod(npt,R3), &
-                         mimicsbiome%Kmod(npt,K1),mimicsbiome%Kmod(npt,K2),mimicsbiome%Kmod(npt,K3)
-          close(214)
+!         write(214,102) npt,casamet%ijgcm(npt),iYrCnt,idoy,casamet%tsoilavg(npt),mimicsflux%Chresp(npt), &
+!                        mimicsflux%ClitInput(npt,metbc),mimicsflux%ClitInput(npt,struc), &
+!                        mimicspool%LITm(npt),mimicspool%LITs(npt),mimicspool%MICr(npt), &
+!                        mimicspool%MICk(npt),mimicspool%SOMa(npt),mimicspool%SOMc(npt),mimicspool%SOMp(npt), &
+!                        dLITm, dLITs, dMICr, dMICk, dSOMa, dSOMc, dSOMp,&
+!
+!                        LITmin(1), LITmin(2), LITmin(3), LITmin(4), &
+!                        MICtrn(1), MICtrn(2), MICtrn(3), MICtrn(4), MICtrn(5), MICtrn(6), &
+!                        SOMmin(1), SOMmin(2), DEsorb, OXIDAT, mimicsbiome%fmet(npt), &
+!
+!                        mimicsbiome%tauMod(npt), mimicsbiome%tauR(npt), mimicsbiome%tauK(npt), &
+!                        mimicsbiome%Vmax(npt,R1),mimicsbiome%Vmax(npt,R2),mimicsbiome%Vmax(npt,R3), &
+!                        mimicsbiome%Vmax(npt,K1),mimicsbiome%Vmax(npt,K2),mimicsbiome%Vmax(npt,K3), &
+!                        mimicsbiome%Km(npt,R1),mimicsbiome%Km(npt,R2),mimicsbiome%Km(npt,R3), &
+!                        mimicsbiome%Km(npt,K1),mimicsbiome%Km(npt,K2),mimicsbiome%Km(npt,K3), &
+!                        mimicsbiome%Vslope(R1),mimicsbiome%Vslope(R2),mimicsbiome%Vslope(R3), &
+!                        mimicsbiome%Vslope(K1),mimicsbiome%Vslope(K2),mimicsbiome%Vslope(K3), &
+!                        mimicsbiome%Kslope(R1),mimicsbiome%Kslope(R2),mimicsbiome%Kslope(R3), &
+!                        mimicsbiome%Kslope(K1),mimicsbiome%Kslope(K2),mimicsbiome%Kslope(K3), &
+!                        mimicsbiome%Vint(R1),mimicsbiome%Kint(R1),Tsoil,casamet%moistavg(npt), &
+!
+!                        casaflux%CnppAn(npt),casapool%clitter(npt,cwd),mimicsbiome%ligninNratioAvg(npt), &
+!                        cleaf2met(npt),cleaf2str(npt),croot2met(npt),croot2str(npt), &
+!                        cwd2str(npt),cwd2co2(npt),cwood2cwd(npt), &
+!
+!                        mimicsbiome%fAVAL(npt,1), mimicsbiome%fAVAL(npt,2), mimicsbiome%fCHEM(npt,1), &
+!                        mimicsbiome%fCHEM(npt,2), mimicsbiome%fPHYS(npt,1), mimicsbiome%fPHYS(npt,2), &
+!
+!                        mimicsbiome%Kmod(npt,R1),mimicsbiome%Kmod(npt,R2),mimicsbiome%Kmod(npt,R3), &
+!                        mimicsbiome%Kmod(npt,K1),mimicsbiome%Kmod(npt,K2),mimicsbiome%Kmod(npt,K3)
+!         close(214)
 
       endif 
 
   ENDIF
 
   end do
-
-102  format(4(i6,','),18(f18.10,','),15(f18.10,','),31(f18.10,','),10(f10.4,','),6(f10.4,','),6(f10.4,','))
 
 END SUBROUTINE mimics_soil_forwardMM
 
@@ -611,9 +616,9 @@ SUBROUTINE mimics_soil_reverseMM(mp,iYrCnt,idoy,cleaf2met,cleaf2str,croot2met,cr
   REAL(r_2), parameter :: wfpscoefd=3.22   ! Kelly et al. (2000) JGR, Figure 2b)
   REAL(r_2), parameter :: wfpscoefe=6.6481 ! =wfpscoefd*(wfpscoefb-wfpscoefa)/(wfpscoefa-wfpscoefc)
 
-  if (iptToSave_mimics > 0) then
-      open(214,file=sPtFileNameMIMICS, access='APPEND')
-  endif
+! if (iptToSave_mimics > 0) then
+!     open(214,file=sPtFileNameMIMICS, access='APPEND')
+! endif
 
   NHOURSf = real(NHOURS)
 
@@ -793,46 +798,52 @@ SUBROUTINE mimics_soil_reverseMM(mp,iYrCnt,idoy,cleaf2met,cleaf2str,croot2met,cr
 !     if (casamet%ijgcm(npt) .eq. 10919) then    ! Deciduous broadleaf (4)
 !     if (casamet%ijgcm(npt) .eq. 11018) then    ! Evergreen needleleaf (1)
 !     if (casamet%ijgcm(npt) .eq. 11569) then    ! Evergreen broadleaf (2)
+
       if (casamet%ijgcm(npt) .eq. iptToSave_mimics) then
-          write(214,102) npt,casamet%ijgcm(npt),iYrCnt,idoy,casamet%tsoilavg(npt),mimicsflux%Chresp(npt), &
-                         mimicsflux%ClitInput(npt,metbc),mimicsflux%ClitInput(npt,struc), &
-                         mimicspool%LITm(npt),mimicspool%LITs(npt),mimicspool%MICr(npt), &
-                         mimicspool%MICk(npt),mimicspool%SOMa(npt),mimicspool%SOMc(npt),mimicspool%SOMp(npt), &
-                         dLITm, dLITs, dMICr, dMICk, dSOMa, dSOMc, dSOMp,&
 
-                         LITmin(1), LITmin(2), LITmin(3), LITmin(4), &
-                         MICtrn(1), MICtrn(2), MICtrn(3), MICtrn(4), MICtrn(5), MICtrn(6), &
-                         SOMmin(1), SOMmin(2), DEsorb, OXIDAT, mimicsbiome%fmet(npt), &
+          call WritePointMIMICS(214, sPtFileNameMIMICS, npt, mp, iYrCnt, idoy, &
+              cleaf2met,cleaf2str,croot2met,croot2str,cwd2str,cwd2co2,cwood2cwd, &
+              LITmin, MICtrn, SOMmin, DEsorb, OXIDAT, &
+              dLITm, dLITs, dSOMa, dSOMc, dSOMp, dMICr, dMICk, Tsoil)
 
-                         mimicsbiome%tauMod(npt), mimicsbiome%tauR(npt), mimicsbiome%tauK(npt), &
-                         mimicsbiome%Vmax(npt,R1),mimicsbiome%Vmax(npt,R2),mimicsbiome%Vmax(npt,R3), &
-                         mimicsbiome%Vmax(npt,K1),mimicsbiome%Vmax(npt,K2),mimicsbiome%Vmax(npt,K3), &
-                         mimicsbiome%Km(npt,R1),mimicsbiome%Km(npt,R2),mimicsbiome%Km(npt,R3), &
-                         mimicsbiome%Km(npt,K1),mimicsbiome%Km(npt,K2),mimicsbiome%Km(npt,K3), &
-                         mimicsbiome%Vslope(R1),mimicsbiome%Vslope(R2),mimicsbiome%Vslope(R3), &
-                         mimicsbiome%Vslope(K1),mimicsbiome%Vslope(K2),mimicsbiome%Vslope(K3), &
-                         mimicsbiome%Kslope(R1),mimicsbiome%Kslope(R2),mimicsbiome%Kslope(R3), &
-                         mimicsbiome%Kslope(K1),mimicsbiome%Kslope(K2),mimicsbiome%Kslope(K3), &
-                         mimicsbiome%Vint(R1),mimicsbiome%Kint(R1),Tsoil,casamet%moistavg(npt), &
+!         write(214,102) npt,casamet%ijgcm(npt),iYrCnt,idoy,casamet%tsoilavg(npt),mimicsflux%Chresp(npt), &
+!                        mimicsflux%ClitInput(npt,metbc),mimicsflux%ClitInput(npt,struc), &
+!                        mimicspool%LITm(npt),mimicspool%LITs(npt),mimicspool%MICr(npt), &
+!                        mimicspool%MICk(npt),mimicspool%SOMa(npt),mimicspool%SOMc(npt),mimicspool%SOMp(npt), &
+!                        dLITm, dLITs, dMICr, dMICk, dSOMa, dSOMc, dSOMp,&
+!
+!                        LITmin(1), LITmin(2), LITmin(3), LITmin(4), &
+!                        MICtrn(1), MICtrn(2), MICtrn(3), MICtrn(4), MICtrn(5), MICtrn(6), &
+!                        SOMmin(1), SOMmin(2), DEsorb, OXIDAT, mimicsbiome%fmet(npt), &
+!
+!                        mimicsbiome%tauMod(npt), mimicsbiome%tauR(npt), mimicsbiome%tauK(npt), &
+!                        mimicsbiome%Vmax(npt,R1),mimicsbiome%Vmax(npt,R2),mimicsbiome%Vmax(npt,R3), &
+!                        mimicsbiome%Vmax(npt,K1),mimicsbiome%Vmax(npt,K2),mimicsbiome%Vmax(npt,K3), &
+!                        mimicsbiome%Km(npt,R1),mimicsbiome%Km(npt,R2),mimicsbiome%Km(npt,R3), &
+!                        mimicsbiome%Km(npt,K1),mimicsbiome%Km(npt,K2),mimicsbiome%Km(npt,K3), &
+!                        mimicsbiome%Vslope(R1),mimicsbiome%Vslope(R2),mimicsbiome%Vslope(R3), &
+!                        mimicsbiome%Vslope(K1),mimicsbiome%Vslope(K2),mimicsbiome%Vslope(K3), &
+!                        mimicsbiome%Kslope(R1),mimicsbiome%Kslope(R2),mimicsbiome%Kslope(R3), &
+!                        mimicsbiome%Kslope(K1),mimicsbiome%Kslope(K2),mimicsbiome%Kslope(K3), &
+!                        mimicsbiome%Vint(R1),mimicsbiome%Kint(R1),Tsoil,casamet%moistavg(npt), &
+!
+!                        casaflux%CnppAn(npt),casapool%clitter(npt,cwd),mimicsbiome%ligninNratioAvg(npt), &
+!                        cleaf2met(npt),cleaf2str(npt),croot2met(npt),croot2str(npt), &
+!                        cwd2str(npt),cwd2co2(npt),cwood2cwd(npt), &
+!
+!                        mimicsbiome%fAVAL(npt,1), mimicsbiome%fAVAL(npt,2), mimicsbiome%fCHEM(npt,1), &
+!                        mimicsbiome%fCHEM(npt,2), mimicsbiome%fPHYS(npt,1), mimicsbiome%fPHYS(npt,2), &
+!
+!                        mimicsbiome%Kmod(npt,R1),mimicsbiome%Kmod(npt,R2),mimicsbiome%Kmod(npt,R3), &
+!                        mimicsbiome%Kmod(npt,K1),mimicsbiome%Kmod(npt,K2),mimicsbiome%Kmod(npt,K3)
+!
+!         close(214)
 
-                         casaflux%CnppAn(npt),casapool%clitter(npt,cwd),mimicsbiome%ligninNratioAvg(npt), &
-                         cleaf2met(npt),cleaf2str(npt),croot2met(npt),croot2str(npt), &
-                         cwd2str(npt),cwd2co2(npt),cwood2cwd(npt), &
-
-                         mimicsbiome%fAVAL(npt,1), mimicsbiome%fAVAL(npt,2), mimicsbiome%fCHEM(npt,1), &
-                         mimicsbiome%fCHEM(npt,2), mimicsbiome%fPHYS(npt,1), mimicsbiome%fPHYS(npt,2), &
-
-                         mimicsbiome%Kmod(npt,R1),mimicsbiome%Kmod(npt,R2),mimicsbiome%Kmod(npt,R3), &
-                         mimicsbiome%Kmod(npt,K1),mimicsbiome%Kmod(npt,K2),mimicsbiome%Kmod(npt,K3)
-
-          close(214)
       endif 
 
   ENDIF
 
   end do
-
-102  format(4(i6,','),18(f18.10,','),15(f18.10,','),31(f18.10,','),10(f10.4,','),6(f10.4,','),6(f10.4,','))
 
 END SUBROUTINE mimics_soil_reverseMM
 

--- a/SOURCE_CODE_05.13.2017/mimics_inout.f90
+++ b/SOURCE_CODE_05.13.2017/mimics_inout.f90
@@ -9,6 +9,7 @@
 !     SUBROUTINE mimics_poolfluxout - write mimics pools to restart .csv output file
 !     SUBROUTINE WritePoolFluxNcFile_mimics_annual - write annual mimics pools and fluxes to netCDF file
 !     SUBROUTINE WritePoolFluxNcFile_mimics_daily - write daily mimics pools and fluxes to netCDF file
+!     SUBROUTINE WritePointMIMICS - write daily mimics pools and other quantities to a .csv file daily
 !
 ! Contact: Melannie Hartman
 !          melannie@ucar.edu
@@ -1807,6 +1808,71 @@ END SUBROUTINE WritePoolFluxNcFile_mimics_annual
 END SUBROUTINE WritePoolFluxNcFile_mimics_daily
 
 !-------------------------------------------------------------------------------------
+! Write MIMICS pools and other quantities to .csv output daily
+
+SUBROUTINE WritePointMIMICS(unit1, sPtFileName, npt, mp, iYrCnt, idoy, &
+    cleaf2met,cleaf2str,croot2met,croot2str,cwd2str,cwd2co2,cwood2cwd, &
+    LITmin, MICtrn, SOMmin, DEsorb, OXIDAT, &
+    dLITm, dLITs, dSOMa, dSOMc, dSOMp, dMICr, dMICk, Tsoil)
+
+    USE define_types
+    USE casadimension
+    USE casaparm
+    USE casavariable
+    USE clmgridvariable
+    USE mimicsdimension
+    USE mimicsparam
+    USE mimicsvariable
+    implicit none
+
+!   ARGUMENTS
+    integer, intent(in)            :: unit1         ! FORTRAN file unit
+    character(len=*), intent(in)   :: sPtFileName   ! .csv output file name 
+    integer, intent(IN)            :: mp, npt       ! # points, point index
+    integer, intent(IN)            :: iYrCnt, idoy  ! simulation year count, day of year
+    real, dimension(mp),intent(IN) :: cleaf2met,cleaf2str,croot2met,croot2str
+    real, dimension(mp),intent(IN) :: cwd2str,cwd2co2,cwood2cwd
+    real(r_2), intent(IN)          :: LITmin(4), MICtrn(6), SOMmin(2), DEsorb, OXIDAT
+    real(r_2), intent(IN)          :: dLITm, dLITs, dSOMa, dSOMc, dSOMp, dMICr, dMICk, Tsoil
 
 
+    open(unit1,file=sPtFileNameMIMICS, access='APPEND')
 
+    write(unit1,102) npt,casamet%ijgcm(npt),iYrCnt,idoy,casamet%tsoilavg(npt),mimicsflux%Chresp(npt), &
+                   mimicsflux%ClitInput(npt,metbc),mimicsflux%ClitInput(npt,struc), &
+                   mimicspool%LITm(npt),mimicspool%LITs(npt),mimicspool%MICr(npt), &
+                   mimicspool%MICk(npt),mimicspool%SOMa(npt),mimicspool%SOMc(npt),mimicspool%SOMp(npt), &
+                   dLITm, dLITs, dMICr, dMICk, dSOMa, dSOMc, dSOMp,&
+
+                   LITmin(1), LITmin(2), LITmin(3), LITmin(4), &
+                   MICtrn(1), MICtrn(2), MICtrn(3), MICtrn(4), MICtrn(5), MICtrn(6), &
+                   SOMmin(1), SOMmin(2), DEsorb, OXIDAT, mimicsbiome%fmet(npt), &
+
+                   mimicsbiome%tauMod(npt), mimicsbiome%tauR(npt), mimicsbiome%tauK(npt), &
+                   mimicsbiome%Vmax(npt,R1),mimicsbiome%Vmax(npt,R2),mimicsbiome%Vmax(npt,R3), &
+                   mimicsbiome%Vmax(npt,K1),mimicsbiome%Vmax(npt,K2),mimicsbiome%Vmax(npt,K3), &
+                   mimicsbiome%Km(npt,R1),mimicsbiome%Km(npt,R2),mimicsbiome%Km(npt,R3), &
+                   mimicsbiome%Km(npt,K1),mimicsbiome%Km(npt,K2),mimicsbiome%Km(npt,K3), &
+                   mimicsbiome%Vslope(R1),mimicsbiome%Vslope(R2),mimicsbiome%Vslope(R3), &
+                   mimicsbiome%Vslope(K1),mimicsbiome%Vslope(K2),mimicsbiome%Vslope(K3), &
+                   mimicsbiome%Kslope(R1),mimicsbiome%Kslope(R2),mimicsbiome%Kslope(R3), &
+                   mimicsbiome%Kslope(K1),mimicsbiome%Kslope(K2),mimicsbiome%Kslope(K3), &
+                   mimicsbiome%Vint(R1),mimicsbiome%Kint(R1),Tsoil,casamet%moistavg(npt), &
+
+                   casaflux%CnppAn(npt),casapool%clitter(npt,cwd),mimicsbiome%ligninNratioAvg(npt), &
+                   cleaf2met(npt),cleaf2str(npt),croot2met(npt),croot2str(npt), &
+                   cwd2str(npt),cwd2co2(npt),cwood2cwd(npt), &
+
+                   mimicsbiome%fAVAL(npt,1), mimicsbiome%fAVAL(npt,2), mimicsbiome%fCHEM(npt,1), &
+                   mimicsbiome%fCHEM(npt,2), mimicsbiome%fPHYS(npt,1), mimicsbiome%fPHYS(npt,2), &
+
+                   mimicsbiome%Kmod(npt,R1),mimicsbiome%Kmod(npt,R2),mimicsbiome%Kmod(npt,R3), &
+                   mimicsbiome%Kmod(npt,K1),mimicsbiome%Kmod(npt,K2),mimicsbiome%Kmod(npt,K3)
+
+    close(unit1)
+
+102  format(4(i6,','),18(f18.10,','),15(f18.10,','),31(f18.10,','),10(f10.4,','),6(f10.4,','),6(f10.4,','))
+
+END SUBROUTINE WritePointMIMICS
+
+!-------------------------------------------------------------------------------------


### PR DESCRIPTION
Issue #12 (casa_inout.f90): Column header line added to CASACNP pool initialization/restart files.
Subroutine casa_init(), that reads the initialization/restart file, assumes there is a column header
line and was updated to skip past the first line in the file. Subroutine write_cnpepool_header()
was created and added to casa_inout.f90 to write a column header line to .csv restart files.
Subroutine write_cnpflux_header() was created and added to casa_inout.f90 to write a column header
line .csv output flux files (for example cnpflux_end_*.csv). The .csv flux output files are indeed
output only.

Issue #13 (casaoffline_driver_clm.f90): Size allocated to CORPSE output structure depends on size of met.nc file.
Read the number of years in the met.nc file to determine the number of timesteps needed in the
CORPSE output file data structures.  Previously the allocation to these output data structures
assumed a max number of 7 years. This was an OK assumption when running a 2-degree grid because
the size of met.nc files could not exceed 2GB, which was 5-7 years, depending on the number of
variables strored in the met.nc files. Seven is not a sufficient number of years for the point
weather input files that may contain many more than 7 years wihout exceeding the maximum netcdf file size.

Issue #14 (corpse_cycle.f90, corpse_soil_carbon.f90): Updates to CORPSE fW calculation
Add parameter fWmin, the minimum soil moisture effect on decomposition, to the CORPSE parameter file.
Save CORPSE fW function (soil moisture effect on soil decomposition) to the output file.Issue #13 (casaoffline_driver_clm.f90): Size allocated to CORPSE output structure depends on size of met.nc file.

Issue #15 (mimics_cycle.f90, mimics_input.f90): Write MIMICS point output to .csv file
The subroutine WritePointMIMICS was created and added to mimics_inout.f90 to write daily output
from MIMICS point simulations to a .csv file. Some output code formerly in mimics_cycle.f90, was moved
to this subroutine.